### PR TITLE
Ensure the CSV downloads' cache key is refreshed

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -42,7 +42,7 @@ jobs:
         id: cachekey
         run: |
           set -xeu
-          KEY="RB Tables $(curl -Is https://cdn.rebrickable.com/media/downloads/parts.csv.gz \
+          KEY="RB Tables $(curl -Is "https://cdn.rebrickable.com/media/downloads/parts.csv.gz?$(date +%s)" \
             | grep -iPo '^last-modified:\s*\K[^\r]+' \
             | tr -d , \
             || date --utc "+%Y%m%d%H")"


### PR DESCRIPTION
It is necessary to set an extra query parameter to ensure that the latest download's headers are returned. Otherwise a previous day's cache can be reused even though the latest content has changed.

See here https://github.com/ojuuji/rb.db/actions/runs/19985555535/job/57318898414#step:5:20

The action gets `KEY='RB Tables Fri 05 Dec 2025 07:12:01 GMT'`
But today's download is `RB Tables Sat 06 Dec 2025 07:12:01 GMT`